### PR TITLE
Publicize state.rawInventory for CU use

### DIFF
--- a/source/MechLabFix/MechLabFixPublic.cs
+++ b/source/MechLabFix/MechLabFixPublic.cs
@@ -14,4 +14,6 @@ public static class MechLabFixPublic
     {
         MechLabFixFeature.state?.FilterChanged();
     }
+
+    public static List<ListElementController_BASE_NotListView> RawInventory => MechLabFixFeature.state?.rawInventory;
 }


### PR DESCRIPTION
CustomUnits use state.rawInventory in Store/Restore feature (?), thus it is not buildable in current state.

There is two issues - first that CU use old `MechLabFix` declaration, not new `MechLabFixFeature` and second - current declaration of `MechLabFixFeature` has been declared as `internal` and thus - not accessible outside assebly.

This PR makes `state.rawInventory` accessible for CU in same way as parts of BPF made accessible for CustomComponents